### PR TITLE
feat: Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,59 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_type:
+        description: 'The type of version bump to apply (major, minor, patch, or a specific version)'
+        required: true
+        default: 'patch'
+        type: choice
+        options:
+        - major
+        - minor
+        - patch
+      prerelease:
+        description: 'Whether this is a pre-release'
+        required: true
+        default: false
+        type: boolean
+
+jobs:
+  test:
+    uses: ./.github/workflows/testing.yml
+
+  release:
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Git
+        run: |
+          git config --global user.name "github-actions"
+          git config --global user.email "github-actions@github.com"
+
+      - name: Update version
+        id: version
+        uses: Mathieu-Beliveau/rust-version-action@v1
+        with:
+          version-type: ${{ github.event.inputs.version_type }}
+          pre-release: ${{ github.event.inputs.prerelease }}
+
+      - name: Create Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ steps.version.outputs.version }}
+          CHANGELOG: ${{ steps.version.outputs.changelog }}
+        run: |
+          PRERELEASE_FLAG=""
+          if [[ "${{ github.event.inputs.prerelease }}" == "true" ]]; then
+            PRERELEASE_FLAG="--prerelease"
+          fi
+          gh release create "$TAG_NAME" \
+            --title "Release $TAG_NAME" \
+            --notes "$CHANGELOG" \
+            $PRERELEASE_FLAG


### PR DESCRIPTION
This commit adds a new GitHub Actions workflow to automate the release process.

The workflow is triggered manually via `workflow_dispatch` and includes the following steps:
- Runs the test suite.
- Updates the version in `Cargo.toml` based on user input (major, minor, patch).
- Commits the version change.
- Creates a GitHub Release with a release note.
- Supports pre-releases.

This workflow improves the release process by automating the manual steps and ensuring that all releases are tested and versioned correctly.