### PR TITLE
feat: Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Set up Git
         run: |
@@ -41,11 +43,12 @@ jobs:
         uses: tj-actions/cargo-bump@v3
         with:
           release_type: ${{ github.event.inputs.version_type }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG_NAME: ${{ steps.version.outputs.tag }}
+          TAG_NAME: ${{ steps.version.outputs.new_tag }}
         run: |
           PRERELEASE_FLAG=""
           if [[ "${{ github.event.inputs.prerelease }}" == "true" ]]; then


### PR DESCRIPTION
This commit adds a new GitHub Actions workflow to automate the release process.

The workflow is triggered manually via `workflow_dispatch` and includes the following steps:
- Runs the test suite.
- Bumps the version in `Cargo.toml`, commits the change, and pushes a new tag using the `tj-actions/cargo-bump` action.
- Creates a GitHub Release with auto-generated release notes.
- Supports pre-releases.

This workflow improves the release process by automating the manual steps and ensuring that all releases are tested and versioned correctly.