### PR TITLE
fix: Replace cargo-bump action with cargo set-version for version bum…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,12 +38,11 @@ jobs:
           git config --global user.name "github-actions"
           git config --global user.email "github-actions@github.com"
 
+      - name: Install cargo-edit
+        run: cargo install cargo-edit --locked
+
       - name: Bump version
-        id: version
-        uses: tj-actions/cargo-bump@v3
-        with:
-          release_type: ${{ github.event.inputs.version_type }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+        run: cargo set-version --workspace --bump ${{ github.event.inputs.version_type }}
 
       - name: Get version
         id: get_version


### PR DESCRIPTION
This pull request updates the release workflow to improve how Rust crate versions are bumped. Instead of using the `tj-actions/cargo-bump` GitHub Action, it now installs and uses the `cargo-edit` tool directly for version management.

**Release workflow improvements:**

* The workflow installs `cargo-edit` using `cargo install cargo-edit --locked` to provide version management commands.
* The version bump step now uses `cargo set-version --workspace --bump` instead of the `tj-actions/cargo-bump` action, simplifying dependencies and allowing more direct control over the versioning process.…