### PR TITLE
fix: Deduplicate external operations by name to prevent registration errors and add a test for duplicate op handling.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6639,6 +6639,7 @@ dependencies = [
  "deno_runtime",
  "env_logger",
  "ext_plugin",
+ "indexmap 2.12.1",
  "ipc-channel",
  "log",
  "node_resolver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ thiserror = "2.0.17"
 url = "2.5.7"
 windows-sys = { version = "0.61.2", features = ["Win32_System_SystemInformation"] }
 regex = "1.11.1"
+indexmap = "2.7"
 
 sys_traits = "0.1.17"
 deno_lib = "0.39.0"
@@ -89,6 +90,7 @@ serde_json = "1.0.145"
 regex.workspace = true
 serde.workspace = true
 ipc-channel = { version = "0.20.2", features = ["async"] }
+indexmap.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 windows-sys.workspace = true

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -14,6 +14,7 @@ use crate::permission::{
 
 use crate::plugin::CorePluginExternalPackage;
 use deno_core::{Extension, JsRuntime, OpDecl, RuntimeOptions, error::JsError};
+use indexmap::IndexMap;
 use std::boxed::Box;
 use std::future::Future;
 use std::sync::{Arc, Mutex};
@@ -180,9 +181,10 @@ pub(crate) fn run_script(
     // Register the extension with the provided operations
     // Deduplicate operations by name to prevent registration errors when multiple
     // external plugins use the same bridge op.
-    let mut unique_ops = std::collections::HashMap::new();
+    // Use IndexMap to preserve insertion order - the first occurrence is kept.
+    let mut unique_ops = IndexMap::new();
     for op in ext_func {
-        unique_ops.insert(op.name.to_string(), op);
+        unique_ops.entry(op.name.to_string()).or_insert(op);
     }
     let deduped_ops: Vec<OpDecl> = unique_ops.into_values().collect();
 
@@ -1112,11 +1114,12 @@ mod per_plugin_permission_tests {
 
         // Pass the same op twice
         let ops = vec![test_op_dup(), test_op_dup()];
-        let script = "1 + 1;";
+        // Call the operation from JavaScript to verify it's registered and functional
+        let script = "Deno.core.ops.test_op_dup();";
         let result = run_script(script, ops, None, None);
         assert!(
             result.is_ok(),
-            "run_script should handle duplicate ops by ignoring duplicates"
+            "run_script should handle duplicate ops by ignoring duplicates and the op should be accessible from JavaScript"
         );
     }
 }


### PR DESCRIPTION
This pull request enhances the robustness of the `run_script` function in the runtime by ensuring that duplicate operations (ops) are deduplicated before registration, preventing errors when multiple plugins register the same operation. Additionally, a new test is added to verify this deduplication behavior.

**Runtime improvements:**

* Updated `run_script` in `src/runtime.rs` to deduplicate operations by name before registering them, preventing errors when multiple plugins provide the same op.

**Testing:**

* Added a unit test `test_run_script_duplicate_ops_handled` to verify that `run_script` correctly ignores duplicate ops and does not fail when duplicates are present