### PR TITLE
Fix rsjsbridge

### DIFF
--- a/src/extplugin_rsjs_bridge.rs
+++ b/src/extplugin_rsjs_bridge.rs
@@ -167,12 +167,12 @@ pub fn rsjs_bridge_opdecl(
 ) -> Result<String, deno_error::JsErrorBox> {
     // Use serde_json::Value and manual string conversion to avoid issues with #[string]
     // attribute on arguments in reentrant ops, which can cause serde_v8 errors.
-    let args_json = args_json_val.as_str().ok_or_else(|| {
-        deno_error::JsErrorBox::type_error("Expected string for args_json")
-    })?;
-    let package_id = package_id_val.as_str().ok_or_else(|| {
-        deno_error::JsErrorBox::type_error("Expected string for package_id")
-    })?;
+    let args_json = args_json_val
+        .as_str()
+        .ok_or_else(|| deno_error::JsErrorBox::type_error("Expected string for args_json"))?;
+    let package_id = package_id_val
+        .as_str()
+        .ok_or_else(|| deno_error::JsErrorBox::type_error("Expected string for package_id"))?;
 
     rsjs_bridge_core(state, args_json, package_id)
         .map_err(|e| deno_error::JsErrorBox::generic(format!("Rs-Js Bridge Error: {e}")))

--- a/tests/integration_extplugin.rs
+++ b/tests/integration_extplugin.rs
@@ -1014,7 +1014,10 @@ globalThis.Sapphillon = {
     code.run(tokio_runtime.handle().clone(), None, None);
 
     if code.result[0].exit_code != 0 {
-        println!("Workflow failed with exit code {}", code.result[0].exit_code);
+        println!(
+            "Workflow failed with exit code {}",
+            code.result[0].exit_code
+        );
         println!("Result: {}", code.result[0].result);
         println!("Description: {}", code.result[0].description);
     }


### PR DESCRIPTION
This pull request addresses a recurring serialization error when calling Rust ops from JavaScript, specifically related to the use of the `#[string]` attribute and `serde_v8`. The main fix involves changing how arguments are handled in the `rsjs_bridge_opdecl` function to prevent type mismatches, and an integration test is added to verify the solution.

**Bug Fixes:**

* Updated `rsjs_bridge_opdecl` in `src/extplugin_rsjs_bridge.rs` to accept `serde_json::Value` for arguments instead of using the `#[string]` attribute, manually converting them to strings and providing clear error messages if the types are incorrect. This prevents `serde_v8` errors when called from JavaScript.

**Testing Improvements:**

* Added a new integration test `test_integration_repro_serde_v8_error` in `tests/integration_extplugin.rs` to reproduce and verify that the serialization error is resolved. The test simulates a JavaScript plugin call and ensures no type mismatch or panic occurs.