### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,6 +1,9 @@
 # This workflow runs Rust tests and checks on push and pull request events
 name: Rust Testing
 
+permissions:
+  contents: read
+
 on:
   pull_request:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/Sapphillon/Sapphillon-Core/security/code-scanning/3](https://github.com/Sapphillon/Sapphillon-Core/security/code-scanning/3)

In general, to fix this type of issue you should explicitly define a `permissions:` block at either the workflow level (applies to all jobs) or the specific job level, granting only the scopes actually required (typically `contents: read` for workflows that only check out code and run tests). This prevents the workflow from inheriting potentially broader repository/organization defaults.

For this workflow, the simplest and safest fix without changing functionality is to add a top-level `permissions:` block right after the `name: Rust Testing` line, with `contents: read`. None of the jobs perform any write operations to the repository (they just check out code, install dependencies, build, and test), so `contents: read` is sufficient. Adding it at the workflow root automatically limits the GITHUB_TOKEN for both `test` and `check` jobs, including the one CodeQL flagged starting at line 66. No additional imports or methods are needed; this is purely a YAML configuration change in `.github/workflows/testing.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
