### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,9 @@ on:
         default: false
         type: boolean
 
+permissions:
+  contents: read
+
 jobs:
   test:
     uses: ./.github/workflows/testing.yml


### PR DESCRIPTION
Potential fix for [https://github.com/Sapphillon/Sapphillon-Core/security/code-scanning/2](https://github.com/Sapphillon/Sapphillon-Core/security/code-scanning/2)

In general, the fix is to explicitly set a `permissions` block instead of relying on implicit repository/organization defaults. For this workflow, we already grant `contents: write` to the `release` job (needed for committing, pushing, and creating releases). The `test` job, which invokes a reusable testing workflow, should be given the least possible permissions—typically `contents: read` is sufficient to run tests.

The best minimal change is to add a `permissions` block scoped to the `test` job, so that the reusable workflow runs with read-only access to repository contents. This preserves existing behavior for `release` (which already has `contents: write`) and does not affect any other workflows. Concretely, in `.github/workflows/release.yml`, under `jobs:`, in the `test` job definition right below `uses: ./.github/workflows/testing.yml`, add:

```yaml
    permissions:
      contents: read
```

No imports or additional methods are needed, as this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
